### PR TITLE
Update Icon ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,4 @@ test.js
 test.coffee
 karg.png
 package.noon
-Icon
+Icon?


### PR DESCRIPTION
The raw CR character in the ignore file wasn't resulting in matches, and as such the `Icon\r` was ending up in the npm package. This made it impossible to install for windows users. (See https://github.com/npm/npm/issues/11702)
